### PR TITLE
Update GNOME runtime to 40 & drop libhandy dep

### DIFF
--- a/org.gnome.gitlab.YaLTeR.Identity.json
+++ b/org.gnome.gitlab.YaLTeR.Identity.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.gitlab.YaLTeR.Identity",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -32,25 +32,6 @@
         }
     },
     "modules" : [
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dintrospection=disabled",
-                "-Dvapi=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.0.0",
-                    "commit": "94313c206258860b2428712e7ece1d02c5177857"
-                }
-            ]
-        },
         {
             "name" : "identity",
             "buildsystem" : "meson",


### PR DESCRIPTION
libhandy now is a part of new GNOME 40 runtime.